### PR TITLE
Add ReLU activation function implementation

### DIFF
--- a/functions/machine-learning/relu.py
+++ b/functions/machine-learning/relu.py
@@ -1,0 +1,13 @@
+import numpy as np
+
+def relu(x):
+    """
+    @brief Applies the Rectified Linear Unit (ReLU) activation function.
+
+    The ReLU function returns the input value if it is greater than 0; otherwise, it returns 0.
+
+    @param x Input value or array.
+
+    @return The result of applying the ReLU function element-wise to the input.
+    """
+    return np.maximum(0, x)


### PR DESCRIPTION
This pull request includes the addition of a new function to apply the Rectified Linear Unit (ReLU) activation function in the `functions/machine-learning/relu.py` file.

New functionality:

* [`functions/machine-learning/relu.py`](diffhunk://#diff-d402d33d392ba013da24914e8081e5c17566ae54529f9d63ec001eb3a733507bR1-R13): Added the `relu` function which uses NumPy to apply the ReLU activation function element-wise to the input. This function returns the input value if it is greater than 0; otherwise, it returns 0.